### PR TITLE
Fill up Spanish translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -19,13 +19,13 @@ msgstr ""
 
 #: src/MainWindow.vala:39
 msgid "Nimbus"
-msgstr ""
+msgstr "Nimbus"
 
 #: src/MainWindow.vala:88
 msgid "Unable to Get Location"
-msgstr ""
+msgstr "No fue posible encontrar tu ubicación"
 
 #: src/MainWindow.vala:121
 #, c-format
 msgid "%i°"
-msgstr ""
+msgstr "%iº"

--- a/po/es.po
+++ b/po/es.po
@@ -28,4 +28,4 @@ msgstr "No fue posible encontrar tu ubicación"
 #: src/MainWindow.vala:121
 #, c-format
 msgid "%i°"
-msgstr "%iº"
+msgstr "%i°"


### PR DESCRIPTION
Feel free to change the symbol "º" (which is what Spanish keyboards can type) to your smaller version "°", it makes no difference. And if you want to translate the application's name, "Nimbus" would become "Nimbo" – which is a Spanish word that I like, actually.